### PR TITLE
pclzip.lib.php privDeleteByRule: fix privCloseFd not called on regular run

### DIFF
--- a/pclzip.lib.php
+++ b/pclzip.lib.php
@@ -4973,9 +4973,9 @@
         if (($v_result = $this->privWriteCentralHeader(0, 0, 0, '')) != 1) {
           return $v_result;
         }
-
-        $this->privCloseFd();
     }
+
+    $this->privCloseFd();
 
     // ----- Return
     return $v_result;


### PR DESCRIPTION
- the `Remove every files` branch closed the FD twice (first time on [L4967](https://github.com/fvgoto/PclZip/blob/main/pclzip.lib.php#L4967))
- in the regular return case (at the end of the method), FD was not closed

In my opinion, the `privCloseFd()` call was misplaced.

The effect of not closing FD was that any further action after deleting a file from the ZIP yield the error
  `Zip file already open` [(in privOpenFd)](https://github.com/fvgoto/PclZip/blob/main/pclzip.lib.php#L2350)