### PR TITLE
Detect Windows using `PHP_OS` to  instead of `php_uname()` in case it's disabled

### DIFF
--- a/pclzip.lib.php
+++ b/pclzip.lib.php
@@ -5680,7 +5680,7 @@
   // --------------------------------------------------------------------------------
   function PclZipUtilTranslateWinPath($p_path, $p_remove_disk_letter=true)
   {
-    if (stristr(php_uname(), 'windows')) {
+    if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN')) {
       // ----- Look for potential disk letter
       if (($p_remove_disk_letter) && (($v_position = strpos($p_path, ':')) != false)) {
           $p_path = substr($p_path, $v_position+1);

--- a/pclzip.lib.php
+++ b/pclzip.lib.php
@@ -5680,7 +5680,7 @@
   // --------------------------------------------------------------------------------
   function PclZipUtilTranslateWinPath($p_path, $p_remove_disk_letter=true)
   {
-    if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN')) {
+    if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
       // ----- Look for potential disk letter
       if (($p_remove_disk_letter) && (($v_position = strpos($p_path, ':')) != false)) {
           $p_path = substr($p_path, $v_position+1);


### PR DESCRIPTION
[A ticket](https://core.trac.wordpress.org/ticket/57711) was raised in WordPress Core Trac for PclZip by a user whose hosting company disables the `php_uname()` function.

To allow the same check to be performed, and rather than checking if the `php_uname()` function exists, consider using `PHP_OS` and checking the first three characters for `WIN`.

Variations of this approach are used in WordPress Core, PHPMailer and getid3, for example.